### PR TITLE
index string representation doesn't include brackets

### DIFF
--- a/address_ast.go
+++ b/address_ast.go
@@ -67,18 +67,17 @@ type Index struct {
 	Value interface{}
 }
 
-// String representation of an index. The index value will be contained within
-// square brackets ("[]"). If the index is a string, it will be quoted and
-// escaped using go's string escaping semantics.
+// String representation of an index. If the index is a string, it will be
+// quoted and escaped using go's string escaping semantics.
 func (i *Index) String() string {
 	if i == nil || i.Value == nil {
 		return ""
 	}
 	switch v := i.Value.(type) {
 	case int:
-		return fmt.Sprintf("[%d]", v)
+		return fmt.Sprintf("%d", v)
 	case string:
-		return fmt.Sprintf("[%q]", v)
+		return fmt.Sprintf("%q", v)
 	default:
 		panic(fmt.Errorf("got unknown type %T", v))
 	}
@@ -96,7 +95,10 @@ type Module struct {
 // String representation of the module. The literal `module.` will be
 // prepended.
 func (m *Module) String() string {
-	return fmt.Sprintf("module.%s%s", m.Name, m.Index.String())
+	if idx := m.Index.String(); idx != "" {
+		return fmt.Sprintf("module.%s[%s]", m.Name, idx)
+	}
+	return fmt.Sprintf("module.%s", m.Name)
 }
 
 // ResourceSpec describes the resource of an address.
@@ -109,5 +111,8 @@ type ResourceSpec struct {
 
 // String representation of the resource component of an address.
 func (r *ResourceSpec) String() string {
-	return fmt.Sprintf("%s.%s%s", r.Type, r.Name, r.Index.String())
+	if idx := r.Index.String(); idx != "" {
+		return fmt.Sprintf("%s.%s[%s]", r.Type, r.Name, idx)
+	}
+	return fmt.Sprintf("%s.%s", r.Type, r.Name)
 }

--- a/address_test.go
+++ b/address_test.go
@@ -41,6 +41,26 @@ func TestValidAddresses(t *testing.T) {
 	}
 }
 
+func TestIndex(t *testing.T) {
+	var tests = []struct {
+		name     string
+		expected string
+		given    string
+	}{
+		{"string", `"foo"`, `module.foo["foo"].a.b["foo"]`},
+		{"int", "123", "module.foo[123].a.b[123]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := NewAddress(tt.given)
+			require.NoError(t, err)
+			require.Equal(t, a.ResourceSpec.Index.String(), tt.expected)
+			require.Equal(t, a.ModulePath[0].Index.String(), tt.expected)
+		})
+	}
+
+}
+
 func TestIndexEdgecases(t *testing.T) {
 	var tests = []string{
 		`foo"bar"`,


### PR DESCRIPTION
The index string is not very useful if it includes brackets. It's easier to use in the address stringification code, but it makes using the index harder.

This is a backwards compatibility breaking change, however this library is pre 1.0