### PR TITLE
Convert hashicorp/go-terraform-address to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,14 @@
+# If the repository is public, be sure to change to GitHub hosted runners
+name: Lint GitHub Actions Workflows
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: "Check workflow files"
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,3 @@
-# If the repository is public, be sure to change to GitHub hosted runners
 name: Lint GitHub Actions Workflows
 on:
   push:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,6 +8,6 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest

--- a/.github/workflows/go-terraform-address.yml
+++ b/.github/workflows/go-terraform-address.yml
@@ -1,0 +1,14 @@
+name: hashicorp/go-terraform-address/hashicorp/go-terraform-address
+on:
+  push:
+    branches:
+    - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/circleci/golang:1.14
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - run: go get -v -t -d ./...
+    - run: go test -v ./...

--- a/.github/workflows/go-terraform-address.yml
+++ b/.github/workflows/go-terraform-address.yml
@@ -2,13 +2,15 @@ name: hashicorp/go-terraform-address/hashicorp/go-terraform-address
 on:
   push:
     branches:
-    - master
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
       image: docker.mirror.hashicorp.services/circleci/golang:1.14
     steps:
-    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-    - run: go get -v -t -d ./...
-    - run: go test -v ./...
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...
+permissions:
+  contents: read

--- a/.github/workflows/go-terraform-address.yml
+++ b/.github/workflows/go-terraform-address.yml
@@ -9,6 +9,6 @@ jobs:
     container:
       image: docker.mirror.hashicorp.services/circleci/golang:1.14
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - run: go get -v -t -d ./...
     - run: go test -v ./...

--- a/.github/workflows/go-terraform-address.yml
+++ b/.github/workflows/go-terraform-address.yml
@@ -1,9 +1,6 @@
 name: Build
 on:
   push:
-    branches:
-      - master
-      - convert-hashicorp-go-terraform-address-to-actions-20230403-201655
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-terraform-address.yml
+++ b/.github/workflows/go-terraform-address.yml
@@ -1,14 +1,17 @@
-name: hashicorp/go-terraform-address/hashicorp/go-terraform-address
+name: Build
 on:
   push:
     branches:
       - master
+      - convert-hashicorp-go-terraform-address-to-actions-20230403-201655
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: docker.mirror.hashicorp.services/circleci/golang:1.14
     steps:
+      - name: Setup go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: 1.14
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - run: go get -v -t -d ./...
       - run: go test -v ./...

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+# Submit a helpdesk ticket to add any team other than yours referenced in the CODEOWNERS file -- they must be added to collaborators and teams in the repository settings with maintainer privileges. Remove this file as soon as you have completed this

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-# Submit a helpdesk ticket to add any team other than yours referenced in the CODEOWNERS file -- they must be added to collaborators and teams in the repository settings with maintainer privileges. Remove this file as soon as you have completed this
+* @hashicorp/release-engineering


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/hashicorp/go-terraform-address) :tada:

This build is passing: https://github.com/hashicorp/go-terraform-address/actions/runs/4601249327

PR to remove CCI config: #10 

Would also be interested in converting this repo to use `main` instead of `master` -- I can do that after I merge in this PR. 